### PR TITLE
Fix normal-related bugs exposed by computing a normal loss

### DIFF
--- a/lab4d/nnutils/nerf.py
+++ b/lab4d/nnutils/nerf.py
@@ -469,6 +469,15 @@ class NeRF(nn.Module):
         """
         M, N, D, _ = xyz_cam.shape
 
+        xyz_cam = xyz_cam.detach()
+        dir_cam = dir_cam.detach()
+        field2cam = tuple(x.detach() for x in field2cam)
+        frame_id = frame_id.detach() if frame_id is not None else None
+        inst_id = inst_id.detach() if inst_id is not None else None
+        samples_dict = {
+            k: tuple(x.detach() for x in v) if isinstance(v, tuple) else v.detach()
+            for k, v in samples_dict.items()
+        }
         def fn_sdf(xyz_cam):
             xyz = self.backward_warp(
                 xyz_cam,

--- a/lab4d/third_party/quaternion/quaternion.py
+++ b/lab4d/third_party/quaternion/quaternion.py
@@ -12,6 +12,9 @@ class _Quaternion_mul_backward(Function):
     @staticmethod
     @custom_fwd(cast_inputs=torch.half)
     def forward(ctx, grad, inputs_1, inputs_2):
+        inputs_1 = inputs_1.contiguous()
+        inputs_2 = inputs_2.contiguous()
+
         B = inputs_1.shape[0] # batch size, coord dim
         D1 = inputs_1.shape[1]
         D2 = inputs_2.shape[1]  
@@ -25,8 +28,10 @@ class _Quaternion_mul_backward(Function):
     @staticmethod
     @once_differentiable
     @custom_bwd  
-    def backward(ctx, *grad_outputs):
-        grad_out_1, grad_out_2 = grad_outputs
+    def backward(ctx, grad_out_1, grad_out_2):
+        grad_out_1 = grad_out_1.contiguous()
+        grad_out_2 = grad_out_2.contiguous()
+
         grad, inputs_1, inputs_2 = ctx.saved_tensors
         B = inputs_1.shape[0] # batch size, coord dim
         D1 = inputs_1.shape[1]
@@ -115,7 +120,7 @@ class _Quaternion_conjugate(torch.autograd.Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad):
-        return _Quaternion_conjugate.apply(grad)
+        return _Quaternion_conjugate.apply(grad.contiguous())
 
 
 quaternion_conjugate = _Quaternion_conjugate.apply

--- a/lab4d/utils/quat_transform.py
+++ b/lab4d/utils/quat_transform.py
@@ -104,13 +104,16 @@ def _quaternion_3D_mul_4D(a_xyz: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 
 
 def quaternion_mul(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    output_shape = a.shape[:-1] + (4,)
+    a = a.reshape(-1, a.shape[-1])
+    b = b.reshape(-1, b.shape[-1])
     if a.is_cuda:
-        ouput_shape = list(a.shape[:-1]) + [4]
-        return _quaternion_mul_cuda(
-            a.view(-1, a.shape[-1]), b.view(-1, b.shape[-1])
-        ).view(ouput_shape)
-    else:
-        return _quaternion_mul(a, b)
+        return _quaternion_mul_cuda(a, b).view(output_shape)
+    if a.shape[-1] == 3:
+        return _quaternion_3D_mul_4D(a, b).view(output_shape)
+    if b.shape[-1] == 3:
+        return _quaternion_4D_mul_3D(a, b).view(output_shape)
+    return _quaternion_mul(a, b).view(output_shape)
 
 
 def _axis_angle_to_quaternion(axis_angle: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
- Detach all inputs in `compute_normal`, similar to https://github.com/lab4d-org/lab4d/commit/f231a6a27c279b61ee14f240c19ae1b567452f77
- Fix the CPU implementation of `_quaternion_mul`, previously it was not consistent with the CUDA version as it did not support `quaternion_3D_mul_4D` and `quaternion_4D_mul_3D`
- Make input and grad tensors contiguous in `lab4d/third_party/quaternion/quaternion.py`. Computing a normal loss requires differentiating through `lab4d/nnutils/nerf.py::compute_normal()`, which previously caused the following error:
```
/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/__init__.py:200: UserWarning: Error detected in _Quaternion_mul_backwardBackward. Traceback of forward call that caused the error:
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/function.py", line 274, in apply
    return user_fn(self, *args)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/cuda/amp/autocast_mode.py", line 123, in decorate_bwd
    return bwd(*args, **kwargs)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/../third_party/quaternion/quaternion.py", line 84, in backward
    grad_inputs_1, grad_inputs_2 = _quaternion_mul_backward(grad, inputs_1, inputs_2)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/function.py", line 506, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
 (Triggered internally at /opt/conda/conda-bld/pytorch_1682343997789/work/torch/csrc/autograd/python_anomaly_mode.cpp:114.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/__init__.py:200: UserWarning: 

Previous calculation was induced by _Quaternion_mulBackward. Traceback of forward call that induced the previous calculation:
  File "/home/jefftan/papers/lab4d-clothing/lab4d/train.py", line 51, in <module>
    app.run(main)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/home/jefftan/papers/lab4d-clothing/lab4d/train.py", line 46, in main
    train_ddp(Trainer)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/train.py", line 40, in train_ddp
    trainer.train()
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/trainer.py", line 231, in train
    self.run_one_round(round_count)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/trainer.py", line 251, in run_one_round
    self.train_one_round(round_count)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/trainer.py", line 343, in train_one_round
    loss_dict = self.model(batch)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/nn/parallel/distributed.py", line 1156, in forward
    output = self._run_ddp_forward(*inputs, **kwargs)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/nn/parallel/distributed.py", line 1110, in _run_ddp_forward
    return module_to_run(*inputs[0], **kwargs[0])  # type: ignore[index]
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/model.py", line 73, in forward
    results = self.render(batch, flow_thresh=config["train_res"])
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/model.py", line 233, in render
    results = self.render_samples_chunk(samples_dict, flow_thresh=flow_thresh)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/model.py", line 303, in render_samples_chunk
    results_chunk = self.render_samples(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/model.py", line 341, in render_samples
    multifields_dict, deltas_dict, aux_dict = self.fields.query_multifields(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/multifields.py", line 333, in query_multifields
    ) = field.query_field(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/deformable.py", line 318, in query_field
    feat_dict, deltas, aux_dict = super().query_field(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/feature.py", line 106, in query_field
    feat_dict, deltas, aux_dict = super(FeatureNeRF, self).query_field(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/nerf.py", line 679, in query_field
    jacob_dict = self.compute_jacobian(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/nerf.py", line 773, in compute_jacobian
    jacob_dict["eikonal"], jacob_dict["normal"] = self.compute_normal(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/nerf.py", line 493, in compute_normal
    g = compute_gradient(fn_sdf, xyz_cam)[..., 0]
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/torch_utils.py", line 10, in compute_gradient
    y = fn(x)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/nerf.py", line 482, in fn_sdf
    xyz = self.backward_warp(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/deformable.py", line 140, in backward_warp
    xyz, warp_dict = self.warp(
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/warping.py", line 467, in forward
    out, warp_dict = super().forward(
  File "/home/jefftan/papers/lab4d-clothing/lab4d/nnutils/warping.py", line 326, in forward
    out = dual_quaternion_skinning(se3, xyz, skin_prob)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/geom_utils.py", line 71, in dual_quaternion_skinning
    pts = dual_quaternion_apply((qr_w, qd_w), pts)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/quat_transform.py", line 393, in dual_quaternion_apply
    return quaternion_translation_apply(q, t, point)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/quat_transform.py", line 280, in quaternion_translation_apply
    p = quaternion_apply(q, point)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/quat_transform.py", line 267, in quaternion_apply
    quaternion_point = quaternion_mul(quaternion, point)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/quat_transform.py", line 109, in quaternion_mul
    return _quaternion_mul_cuda(
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/function.py", line 506, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
 (Triggered internally at /opt/conda/conda-bld/pytorch_1682343997789/work/torch/csrc/autograd/python_anomaly_mode.cpp:121.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
Traceback (most recent call last):
  File "/home/jefftan/papers/lab4d-clothing/lab4d/train.py", line 51, in <module>
    app.run(main)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/home/jefftan/papers/lab4d-clothing/lab4d/train.py", line 46, in main
    train_ddp(Trainer)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/train.py", line 40, in train_ddp
    trainer.train()
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/trainer.py", line 231, in train
    self.run_one_round(round_count)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/trainer.py", line 251, in run_one_round
    self.train_one_round(round_count)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/engine/trainer.py", line 345, in train_one_round
    total_loss.mean().backward()
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/_tensor.py", line 487, in backward
    torch.autograd.backward(
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/__init__.py", line 200, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/function.py", line 274, in apply
    return user_fn(self, *args)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/autograd/function.py", line 522, in wrapper
    outputs = fn(ctx, *args)
  File "/home/jefftan/.miniconda3/envs/lab4d/lib/python3.9/site-packages/torch/cuda/amp/autocast_mode.py", line 123, in decorate_bwd
    return bwd(*args, **kwargs)
  File "/home/jefftan/papers/lab4d-clothing/lab4d/utils/../third_party/quaternion/quaternion.py", line 38, in backward
    _backend.quaternion_mul_backward_backward(grad_out_1, grad_out_2,
RuntimeError: grad_out_2 must be a contiguous tensor
```