### PR TITLE
bug fix: skip downloading videos for existing folders in database/raw

### DIFF
--- a/scripts/run_preprocess.py
+++ b/scripts/run_preprocess.py
@@ -114,8 +114,11 @@ if __name__ == "__main__":
     print("using gpus: ", gpulist)
     os.makedirs("tmp", exist_ok=True)
 
-    # download the videos
-    download_seq(vidname)
+    # check if the directory with the video already exists
+    viddir_path = os.path.join("database", "raw", vidname)
+    if not os.path.exists(viddir_path):
+        # download the videos only if the directory does not exist
+        download_seq(vidname)
 
     # set up parallel extraction
     frame_args = []


### PR DESCRIPTION
To preprocess other videos, create a folder named database/raw/$seqname, move the videos into it, and run the above command. # Args: sequence name, text prompt (segmentation), category from {human, quad, other} (camera viewpoint), gpu id python scripts/run_preprocess.py cat-pikachu-0 cat quad "0"

If you do it for custom videos the folder will be deleted and you will have to provide a link to dropbox.
Bug description: https://github.com/lab4d-org/lab4d/issues/20